### PR TITLE
Add integration testing question to Playwright evaluation

### DIFF
--- a/Playwright/CandidateEvaluation.md
+++ b/Playwright/CandidateEvaluation.md
@@ -1,0 +1,20 @@
+# Playwright Candidate Evaluation Questions
+
+This document contains questions designed to assess a candidate's ability to write effective Playwright tests.
+
+1. **End-to-End Login Test**
+   - Write a Playwright test that navigates to a login page, fills out a username and password, submits the form, and verifies that a welcome message appears.
+   - Explain how you would ensure the test waits properly for page navigation and element visibility.
+
+2. **UI Interaction Validation**
+   - Provide a test script that checks whether a dropdown menu becomes visible only when hovering over a specific element.
+   - Describe how you would assert that the menu items are hidden before hovering and visible afterward.
+
+3. **Network Request Mocking**
+   - Demonstrate how to intercept and mock an API response in Playwright to test a component that relies on network data.
+   - Include an explanation of when and why you might use request interception in your test suite.
+
+
+4. **Integration Testing with an API Endpoint**
+   - Write a Playwright test that interacts with a real or mocked API endpoint and verifies that the UI updates based on the response.
+   - Describe how you would configure the test environment to run integration tests that depend on backend services.


### PR DESCRIPTION
## Summary
- remove wording that limited the questions to three
- add a fourth question about integration testing with an API endpoint

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_b_683e62eba340832cb89c18b98105a55f