### PR TITLE
Add Playwright candidate sample project

### DIFF
--- a/Playwright/README.md
+++ b/Playwright/README.md
@@ -1,0 +1,22 @@
+# Playwright Sample Project
+
+This folder contains a minimal Playwright setup with simple HTML pages so you can answer the questions in **CandidateEvaluation.md**. Each test file in `tests/` includes TODO comments where you can implement your solutions.
+
+## Setup
+
+1. Install dependencies (requires internet access):
+   ```bash
+   npm install
+   ```
+2. Run the tests:
+   ```bash
+   npm test
+   ```
+
+## Included pages
+
+- `public/login.html` – simple login form used for the end-to-end login test.
+- `public/dropdown.html` – page with a dropdown menu that appears on hover.
+- `public/api.html` – page that fetches data from `https://randomuser.me/api/` and displays it.
+
+Feel free to modify the tests or pages as needed when completing the evaluation questions.

--- a/Playwright/package.json
+++ b/Playwright/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "playwright-sample",
+  "version": "1.0.0",
+  "description": "Sample project for Playwright candidate evaluation",
+  "main": "index.js",
+  "scripts": {
+    "test": "playwright test"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs",
+  "devDependencies": {
+    "@playwright/test": "^1.42.1"
+  },
+  "dependencies": {
+    "express": "^4.18.2"
+  }
+}

--- a/Playwright/playwright.config.js
+++ b/Playwright/playwright.config.js
@@ -1,0 +1,9 @@
+// @ts-check
+const { defineConfig } = require('@playwright/test');
+
+module.exports = defineConfig({
+  testDir: './tests',
+  use: {
+    headless: true,
+  },
+});

--- a/Playwright/public/api.html
+++ b/Playwright/public/api.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>API Page</title>
+</head>
+<body>
+  <button id="load-user">Load User</button>
+  <pre id="output"></pre>
+  <script>
+    document.getElementById('load-user').addEventListener('click', async () => {
+      const response = await fetch('https://randomuser.me/api/');
+      const data = await response.json();
+      const user = data.results[0];
+      document.getElementById('output').textContent =
+        `${user.name.first} ${user.name.last} - ${user.email}`;
+    });
+  </script>
+</body>
+</html>

--- a/Playwright/public/dropdown.html
+++ b/Playwright/public/dropdown.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Dropdown Page</title>
+  <style>
+    #menu { display: none; position: absolute; background: #eee; padding: 10px; }
+    #trigger:hover + #menu { display: block; }
+  </style>
+</head>
+<body>
+  <div id="trigger" style="width: 100px; height: 30px; background: #ccc;">Hover me</div>
+  <div id="menu">
+    <ul>
+      <li>Item 1</li>
+      <li>Item 2</li>
+      <li>Item 3</li>
+    </ul>
+  </div>
+</body>
+</html>

--- a/Playwright/public/login.html
+++ b/Playwright/public/login.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Login Page</title>
+</head>
+<body>
+  <form id="login-form">
+    <label for="username">Username:</label>
+    <input id="username" name="username" type="text" />
+    <label for="password">Password:</label>
+    <input id="password" name="password" type="password" />
+    <button id="submit" type="submit">Login</button>
+  </form>
+  <p id="message" style="display:none"></p>
+  <script>
+    const form = document.getElementById('login-form');
+    form.addEventListener('submit', (e) => {
+      e.preventDefault();
+      const username = document.getElementById('username').value;
+      const message = document.getElementById('message');
+      message.textContent = `Welcome, ${username}!`;
+      message.style.display = 'block';
+    });
+  </script>
+</body>
+</html>

--- a/Playwright/tests/api-integration.spec.js
+++ b/Playwright/tests/api-integration.spec.js
@@ -1,0 +1,14 @@
+const { test, expect } = require('@playwright/test');
+const path = require('path');
+
+// TODO: Use the real API endpoint and verify UI updates according to CandidateEvaluation.md
+
+test('integration test with real API', async ({ page }) => {
+  const filePath = path.join(__dirname, '../public/api.html');
+  await page.goto('file://' + filePath);
+
+  // Trigger the API request
+  // await page.click('#load-user');
+  // Expect the output to contain data from the API
+  // await expect(page.locator('#output')).not.toBeEmpty();
+});

--- a/Playwright/tests/dropdown.spec.js
+++ b/Playwright/tests/dropdown.spec.js
@@ -1,0 +1,16 @@
+const { test, expect } = require('@playwright/test');
+const path = require('path');
+
+// TODO: Validate dropdown visibility on hover according to CandidateEvaluation.md
+
+test('dropdown appears on hover', async ({ page }) => {
+  const filePath = path.join(__dirname, '../public/dropdown.html');
+  await page.goto('file://' + filePath);
+
+  const menu = page.locator('#menu');
+  await expect(menu).toBeHidden();
+
+  // Hover over the trigger element
+  // await page.hover('#trigger');
+  // await expect(menu).toBeVisible();
+});

--- a/Playwright/tests/login.spec.js
+++ b/Playwright/tests/login.spec.js
@@ -1,0 +1,17 @@
+const { test, expect } = require('@playwright/test');
+const path = require('path');
+
+// TODO: Complete the login test according to CandidateEvaluation.md
+
+test('end-to-end login', async ({ page }) => {
+  const filePath = path.join(__dirname, '../public/login.html');
+  await page.goto('file://' + filePath);
+
+  // Fill in the username and password fields
+  // await page.fill('#username', 'your-username');
+  // await page.fill('#password', 'your-password');
+  // await page.click('#submit');
+
+  // Expect a welcome message to appear
+  // await expect(page.locator('#message')).toHaveText('Welcome, your-username!');
+});

--- a/Playwright/tests/network-mock.spec.js
+++ b/Playwright/tests/network-mock.spec.js
@@ -1,0 +1,21 @@
+const { test, expect } = require('@playwright/test');
+const path = require('path');
+
+// TODO: Intercept and mock the API response according to CandidateEvaluation.md
+
+test('mock API response', async ({ page }) => {
+  const filePath = path.join(__dirname, '../public/api.html');
+  await page.goto('file://' + filePath);
+
+  // Use page.route to intercept the request and return a mocked response
+  // await page.route('https://randomuser.me/api/', async route => {
+  //   await route.fulfill({
+  //     status: 200,
+  //     contentType: 'application/json',
+  //     body: JSON.stringify({ results: [{ name: { first: 'Jane', last: 'Doe' }, email: 'jane.doe@example.com' }] })
+  //   });
+  // });
+
+  // await page.click('#load-user');
+  // await expect(page.locator('#output')).toContainText('Jane Doe');
+});

--- a/README.md
+++ b/README.md
@@ -1,1 +1,3 @@
 # QA-Testing
+
+This repository contains a sample Playwright project located in the `Playwright` folder. Follow the instructions there to install dependencies and run the example tests.


### PR DESCRIPTION
## Summary
- add a README explaining the repo
- create Playwright sample project with placeholder tests
- include HTML pages for login, dropdown and API call example

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_683e6f33528c832c912ef3ff85f81a96