### PR TITLE
Add Selenium test skeletons

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
 # QA-Testing
 
 This repository contains a sample Playwright project located in the `Playwright` folder. The `public` directory with example pages and `CandidateEvaluation.md` are located in the repository root. Follow the instructions in the Playwright folder to install dependencies and run the example tests.
+
+In addition to the Playwright sample, there are Selenium examples in the `Selenium-java`, `Selenium-python` and `Selenium-javascript` folders. Each contains setup instructions and placeholder tests mirroring the evaluation questions.

--- a/Selenium-java/README.MD
+++ b/Selenium-java/README.MD
@@ -1,0 +1,16 @@
+# Selenium Java Sample Project
+
+This folder contains a minimal Selenium setup with JUnit tests that use the pages in `../public` for the candidate evaluation questions.
+
+## Setup
+
+1. Install Java 17+ and Maven.
+2. In this `Selenium-java` directory, run:
+   ```bash
+   mvn test
+   ```
+
+## Project Structure
+
+- `pom.xml` – Maven configuration with Selenium and JUnit dependencies.
+- `src/test/java` – Test classes with TODO sections for the evaluation tasks.

--- a/Selenium-java/pom.xml
+++ b/Selenium-java/pom.xml
@@ -1,0 +1,35 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>com.example</groupId>
+    <artifactId>selenium-sample</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <packaging>jar</packaging>
+    <dependencies>
+        <dependency>
+            <groupId>org.seleniumhq.selenium</groupId>
+            <artifactId>selenium-java</artifactId>
+            <version>4.16.1</version>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>5.10.0</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>3.1.0</version>
+                <configuration>
+                    <includes>
+                        <include>**/*Test.java</include>
+                    </includes>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/Selenium-java/src/test/java/ApiIntegrationTest.java
+++ b/Selenium-java/src/test/java/ApiIntegrationTest.java
@@ -1,0 +1,31 @@
+import org.junit.jupiter.api.*;
+import org.openqa.selenium.*;
+import org.openqa.selenium.chrome.ChromeDriver;
+import java.nio.file.Paths;
+
+public class ApiIntegrationTest {
+    private WebDriver driver;
+
+    @BeforeEach
+    public void setUp() {
+        driver = new ChromeDriver();
+    }
+
+    @AfterEach
+    public void tearDown() {
+        if (driver != null) {
+            driver.quit();
+        }
+    }
+
+    @Test
+    public void integrationWithRealApi() {
+        String fileUrl = Paths.get("../public/api.html").toUri().toString();
+        driver.get(fileUrl);
+
+        // Trigger the real API request
+        // driver.findElement(By.id("load-user")).click();
+        // WebElement output = driver.findElement(By.id("output"));
+        // Assertions.assertFalse(output.getText().isBlank());
+    }
+}

--- a/Selenium-java/src/test/java/DropdownTest.java
+++ b/Selenium-java/src/test/java/DropdownTest.java
@@ -1,0 +1,34 @@
+import org.junit.jupiter.api.*;
+import org.openqa.selenium.*;
+import org.openqa.selenium.chrome.ChromeDriver;
+import org.openqa.selenium.interactions.Actions;
+import java.nio.file.Paths;
+
+public class DropdownTest {
+    private WebDriver driver;
+
+    @BeforeEach
+    public void setUp() {
+        driver = new ChromeDriver();
+    }
+
+    @AfterEach
+    public void tearDown() {
+        if (driver != null) {
+            driver.quit();
+        }
+    }
+
+    @Test
+    public void dropdownAppearsOnHover() {
+        String fileUrl = Paths.get("../public/dropdown.html").toUri().toString();
+        driver.get(fileUrl);
+
+        WebElement menu = driver.findElement(By.id("menu"));
+        Assertions.assertFalse(menu.isDisplayed());
+
+        // Hover over the trigger element
+        // new Actions(driver).moveToElement(driver.findElement(By.id("trigger"))).perform();
+        // Assertions.assertTrue(menu.isDisplayed());
+    }
+}

--- a/Selenium-java/src/test/java/LoginTest.java
+++ b/Selenium-java/src/test/java/LoginTest.java
@@ -1,0 +1,36 @@
+import org.junit.jupiter.api.*;
+import org.openqa.selenium.*;
+import org.openqa.selenium.chrome.ChromeDriver;
+import java.nio.file.Paths;
+
+public class LoginTest {
+    private WebDriver driver;
+
+    @BeforeEach
+    public void setUp() {
+        // TODO: configure WebDriver location or use WebDriverManager
+        driver = new ChromeDriver();
+    }
+
+    @AfterEach
+    public void tearDown() {
+        if (driver != null) {
+            driver.quit();
+        }
+    }
+
+    @Test
+    public void endToEndLogin() {
+        String fileUrl = Paths.get("../public/login.html").toUri().toString();
+        driver.get(fileUrl);
+
+        // TODO: Fill in username and password fields
+        // driver.findElement(By.id("username")).sendKeys("your-username");
+        // driver.findElement(By.id("password")).sendKeys("your-password");
+        // driver.findElement(By.id("submit")).click();
+
+        // TODO: Assert welcome message is displayed
+        // WebElement message = driver.findElement(By.id("welcome-text"));
+        // Assertions.assertEquals("Welcome back, your-username!", message.getText());
+    }
+}

--- a/Selenium-java/src/test/java/NetworkMockTest.java
+++ b/Selenium-java/src/test/java/NetworkMockTest.java
@@ -1,0 +1,33 @@
+import org.junit.jupiter.api.*;
+import org.openqa.selenium.*;
+import org.openqa.selenium.chrome.ChromeDriver;
+import java.nio.file.Paths;
+
+public class NetworkMockTest {
+    private WebDriver driver;
+
+    @BeforeEach
+    public void setUp() {
+        driver = new ChromeDriver();
+    }
+
+    @AfterEach
+    public void tearDown() {
+        if (driver != null) {
+            driver.quit();
+        }
+    }
+
+    @Test
+    public void mockApiResponse() {
+        String fileUrl = Paths.get("../public/api.html").toUri().toString();
+        driver.get(fileUrl);
+
+        // TODO: Intercept the network request to https://randomuser.me/api/
+        // and return a mocked response using a proxy or CDP commands.
+
+        // driver.findElement(By.id("load-user")).click();
+        // WebElement output = driver.findElement(By.id("output"));
+        // Assertions.assertTrue(output.getText().contains("Jane Doe"));
+    }
+}

--- a/Selenium-javascript/README.MD
+++ b/Selenium-javascript/README.MD
@@ -1,0 +1,20 @@
+# Selenium JavaScript Sample Project
+
+This directory shows how to use Selenium with Node.js.
+
+## Setup
+
+1. Install Node.js v18+.
+2. Install dependencies:
+   ```bash
+   npm install
+   ```
+3. Run the tests:
+   ```bash
+   npm test
+   ```
+
+## Contents
+
+- `package.json` – project configuration using mocha.
+- `tests/` – Test files with TODO comments that correspond to the candidate evaluation tasks.

--- a/Selenium-javascript/package.json
+++ b/Selenium-javascript/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "selenium-javascript-sample",
+  "version": "1.0.0",
+  "description": "Sample Selenium project for candidate evaluation",
+  "type": "commonjs",
+  "scripts": {
+    "test": "mocha tests/*.test.js"
+  },
+  "devDependencies": {
+    "mocha": "^10.2.0",
+    "selenium-webdriver": "^4.16.0"
+  }
+}

--- a/Selenium-javascript/tests/api-integration.test.js
+++ b/Selenium-javascript/tests/api-integration.test.js
@@ -1,0 +1,30 @@
+const {Builder, By} = require('selenium-webdriver');
+const path = require('path');
+const assert = require('assert');
+
+// TODO: Use the real API endpoint and verify UI updates
+
+describe('integration test with real API', function() {
+  this.timeout(30000);
+  let driver;
+
+  before(async () => {
+    driver = new Builder().forBrowser('chrome').build();
+  });
+
+  after(async () => {
+    if (driver) {
+      await driver.quit();
+    }
+  });
+
+  it('loads user data', async () => {
+    const filePath = path.resolve(__dirname, '../../public/api.html');
+    await driver.get('file://' + filePath);
+
+    // Trigger the API request
+    // await driver.findElement(By.id('load-user')).click();
+    // const output = await driver.findElement(By.id('output')).getText();
+    // assert.notStrictEqual(output.trim(), '');
+  });
+});

--- a/Selenium-javascript/tests/dropdown.test.js
+++ b/Selenium-javascript/tests/dropdown.test.js
@@ -1,0 +1,33 @@
+const {Builder, By, Actions} = require('selenium-webdriver');
+const path = require('path');
+const assert = require('assert');
+
+describe('dropdown appears on hover', function() {
+  this.timeout(30000);
+  let driver;
+
+  before(async () => {
+    driver = new Builder().forBrowser('chrome').build();
+  });
+
+  after(async () => {
+    if (driver) {
+      await driver.quit();
+    }
+  });
+
+  it('shows menu when hovering', async () => {
+    const filePath = path.resolve(__dirname, '../../public/dropdown.html');
+    await driver.get('file://' + filePath);
+
+    const menu = await driver.findElement(By.id('menu'));
+    let displayed = await menu.isDisplayed();
+    assert.strictEqual(displayed, false);
+
+    // Hover over trigger element
+    // const trigger = await driver.findElement(By.id('trigger'));
+    // await driver.actions({bridge: true}).move({origin: trigger}).perform();
+    // displayed = await menu.isDisplayed();
+    // assert.strictEqual(displayed, true);
+  });
+});

--- a/Selenium-javascript/tests/login.test.js
+++ b/Selenium-javascript/tests/login.test.js
@@ -1,0 +1,32 @@
+const {Builder, By} = require('selenium-webdriver');
+const path = require('path');
+const assert = require('assert');
+
+describe('end-to-end login', function() {
+  this.timeout(30000);
+  let driver;
+
+  before(async () => {
+    driver = new Builder().forBrowser('chrome').build();
+  });
+
+  after(async () => {
+    if (driver) {
+      await driver.quit();
+    }
+  });
+
+  it('logs in successfully', async () => {
+    const filePath = path.resolve(__dirname, '../../public/login.html');
+    await driver.get('file://' + filePath);
+
+    // TODO: Fill in the username and password fields
+    // await driver.findElement(By.id('username')).sendKeys('your-username');
+    // await driver.findElement(By.id('password')).sendKeys('your-password');
+    // await driver.findElement(By.id('submit')).click();
+
+    // TODO: Verify welcome message
+    // const text = await driver.findElement(By.id('welcome-text')).getText();
+    // assert.strictEqual(text, 'Welcome back, your-username!');
+  });
+});

--- a/Selenium-javascript/tests/network-mock.test.js
+++ b/Selenium-javascript/tests/network-mock.test.js
@@ -1,0 +1,30 @@
+const {Builder, By} = require('selenium-webdriver');
+const path = require('path');
+const assert = require('assert');
+
+// TODO: Intercept and mock the API response according to CandidateEvaluation.md
+
+describe('mock API response', function() {
+  this.timeout(30000);
+  let driver;
+
+  before(async () => {
+    driver = new Builder().forBrowser('chrome').build();
+  });
+
+  after(async () => {
+    if (driver) {
+      await driver.quit();
+    }
+  });
+
+  it('displays mocked data', async () => {
+    const filePath = path.resolve(__dirname, '../../public/api.html');
+    await driver.get('file://' + filePath);
+
+    // Use browser devtools protocol or proxy to mock the request
+    // await driver.findElement(By.id('load-user')).click();
+    // const output = await driver.findElement(By.id('output')).getText();
+    // assert(output.includes('Jane Doe'));
+  });
+});

--- a/Selenium-python/README.MD
+++ b/Selenium-python/README.MD
@@ -1,0 +1,22 @@
+# Selenium Python Sample Project
+
+This folder provides a Python setup using pytest and Selenium.
+
+## Setup
+
+1. Create a virtual environment and activate it.
+2. Install dependencies:
+   ```bash
+   pip install -r requirements.txt
+   ```
+3. Run the tests:
+   ```bash
+   pytest
+   ```
+
+The tests open the HTML pages from `../public`.
+
+## Files
+
+- `requirements.txt` – Python dependencies.
+- `tests/` – Test modules containing TODOs for the evaluation questions.

--- a/Selenium-python/requirements.txt
+++ b/Selenium-python/requirements.txt
@@ -1,0 +1,2 @@
+selenium==4.16.0
+pytest==7.4.4

--- a/Selenium-python/tests/test_api_integration.py
+++ b/Selenium-python/tests/test_api_integration.py
@@ -1,0 +1,18 @@
+import pathlib
+from selenium import webdriver
+from selenium.webdriver.common.by import By
+
+# TODO: Use the real API endpoint and verify UI updates
+
+def test_integration_with_real_api():
+    file_url = pathlib.Path("../public/api.html").resolve().as_uri()
+    driver = webdriver.Chrome()
+    try:
+        driver.get(file_url)
+
+        # Trigger the API request
+        # driver.find_element(By.ID, "load-user").click()
+        # output = driver.find_element(By.ID, "output")
+        # assert output.text.strip() != ""
+    finally:
+        driver.quit()

--- a/Selenium-python/tests/test_dropdown.py
+++ b/Selenium-python/tests/test_dropdown.py
@@ -1,0 +1,22 @@
+import pathlib
+from selenium import webdriver
+from selenium.webdriver.common.by import By
+from selenium.webdriver.common.action_chains import ActionChains
+
+# TODO: Validate dropdown visibility on hover according to CandidateEvaluation.md
+
+def test_dropdown_appears_on_hover():
+    file_url = pathlib.Path("../public/dropdown.html").resolve().as_uri()
+    driver = webdriver.Chrome()
+    try:
+        driver.get(file_url)
+
+        menu = driver.find_element(By.ID, "menu")
+        assert not menu.is_displayed()
+
+        # Hover over the trigger element
+        # trigger = driver.find_element(By.ID, "trigger")
+        # ActionChains(driver).move_to_element(trigger).perform()
+        # assert menu.is_displayed()
+    finally:
+        driver.quit()

--- a/Selenium-python/tests/test_login.py
+++ b/Selenium-python/tests/test_login.py
@@ -1,0 +1,23 @@
+import pathlib
+import pytest
+from selenium import webdriver
+from selenium.webdriver.common.by import By
+
+# TODO: Complete the login test according to CandidateEvaluation.md
+
+def test_end_to_end_login(tmp_path):
+    file_url = pathlib.Path("../public/login.html").resolve().as_uri()
+    driver = webdriver.Chrome()
+    try:
+        driver.get(file_url)
+
+        # Fill in the username and password fields
+        # driver.find_element(By.ID, "username").send_keys("your-username")
+        # driver.find_element(By.ID, "password").send_keys("your-password")
+        # driver.find_element(By.ID, "submit").click()
+
+        # Expect a welcome message to appear
+        # message = driver.find_element(By.ID, "welcome-text")
+        # assert message.text == "Welcome back, your-username!"
+    finally:
+        driver.quit()

--- a/Selenium-python/tests/test_network_mock.py
+++ b/Selenium-python/tests/test_network_mock.py
@@ -1,0 +1,18 @@
+import pathlib
+from selenium import webdriver
+from selenium.webdriver.common.by import By
+
+# TODO: Intercept and mock the API response according to CandidateEvaluation.md
+
+def test_mock_api_response():
+    file_url = pathlib.Path("../public/api.html").resolve().as_uri()
+    driver = webdriver.Chrome()
+    try:
+        driver.get(file_url)
+
+        # Use a proxy or CDP commands to mock the request
+        # driver.find_element(By.ID, "load-user").click()
+        # output = driver.find_element(By.ID, "output")
+        # assert "Jane Doe" in output.text
+    finally:
+        driver.quit()


### PR DESCRIPTION
## Summary
- add minimal Selenium examples for Java, Python and JavaScript
- add instructions for each Selenium project
- update root README with Selenium info

## Testing
- `npm test` *(fails: mocha not found)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'selenium')*
- `mvn test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_683ea47f7c60832c874e5618e62eaffb